### PR TITLE
Add Ability to Specify Start and End Times for Tasks

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,7 +5,7 @@ export const DAY_PLANNER_FILENAME = 'Day Planner-{{date}}.md';
 
 //https://regex101.com/r/VAxRnc/8
 export const PLAN_PARSER_REGEX_CREATOR = (breakLabel: string, endLabel: string) =>
-  new RegExp('^(((-?[\\s]*\\[?(?<completion>[x ]*)\\])(\\d.)?\\s*?(?<hours>\\d{1,2}):(?<minutes>\\d{2})\\s)((?<break>' + breakLabel + '[\\n ]?)|(?<end>' + endLabel + '[\\n ]?)|((?<text>.*))))$', 'gmi');
+  new RegExp('^(((-?[\\s]*\\[?(?<completion>[x ]*)\\])(\\d.)?\\s*?(?<hours>\\d{1,2}):(?<minutes>\\d{2})\\s(-\\s(?<endHours>\\d{1,2}):(?<endMinutes>\\d{2}))?)((?<break>' + breakLabel + '[\\n ]?)|(?<end>' + endLabel + '[\\n ]?)|((?<text>.*))))$', 'gmi');
 
 export const MERMAID_REGEX = /```mermaid\ngantt[\S\s]*?```\s*/gmi;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,7 +5,7 @@ export const DAY_PLANNER_FILENAME = 'Day Planner-{{date}}.md';
 
 //https://regex101.com/r/VAxRnc/8
 export const PLAN_PARSER_REGEX_CREATOR = (breakLabel: string, endLabel: string) =>
-  new RegExp('^(((-?[\\s]*\\[?(?<completion>[x ]*)\\])(\\d.)?\\s*?(?<hours>\\d{1,2}):(?<minutes>\\d{2})\\s(-\\s(?<endHours>\\d{1,2}):(?<endMinutes>\\d{2}))?)((?<break>' + breakLabel + '[\\n ]?)|(?<end>' + endLabel + '[\\n ]?)|((?<text>.*))))$', 'gmi');
+  new RegExp('^(((-?[\\s]*\\[?(?<completion>[x ]*)\\])(\\d.)?\\s*?(?<hours>\\d{1,2}):(?<minutes>\\d{2})\\s(((-){1,2}|–)\\s(?<endHours>\\d{1,2}):(?<endMinutes>\\d{2}))?)((?<break>' + breakLabel + '[\\n ]?)|(?<end>' + endLabel + '[\\n ]?)|((?<text>.*))))$', 'gmi');
 
 export const MERMAID_REGEX = /```mermaid\ngantt[\S\s]*?```\s*/gmi;
 

--- a/src/mermaid.ts
+++ b/src/mermaid.ts
@@ -31,7 +31,8 @@ export default class PlannerMermaid {
         items.forEach((item, i) => {
             const next = items[i+1];
             const mins = this.minuteInterval(item, next);
-            const text = `    ${this.escape(item.text)}     :${item.rawTime.replace(':', '-')}${mins}`;
+            // TODO: do I need to do something here pjk
+            const text = `    ${this.escape(item.text)}     :${item.rawStartTime.replace(':', '-')}${mins}`;
             if(item.isBreak) {
                 breaks.push(text);
             } else {
@@ -42,11 +43,16 @@ export default class PlannerMermaid {
     }
 
     private minuteInterval(item: PlanItem, next: PlanItem): string {
-        if(next === undefined){
+        if(next === undefined && item.endTime === undefined){
             return ', 0mm';
         }
-        const currentMoment = moment(item.time);
-        const nextMoment = moment(next.time);
+        const currentMoment = moment(item.startTime);
+        let nextMoment: any;
+        if (item.endTime !== undefined) {
+            nextMoment = moment(item.endTime);
+        } else {
+            nextMoment = moment(next.startTime);
+        }
         const untilNext = Math.floor(moment.duration(nextMoment.diff(currentMoment)).asMinutes());
         return ', ' + untilNext + 'mm';
     }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -40,18 +40,33 @@ export default class Parser {
                 const isCompleted = this.matchValue(value.groups.completion, 'x');
                 const isBreak = value.groups.break !== undefined;
                 const isEnd = value.groups.end !== undefined;
-                const time = new Date();
-                time.setHours(parseInt(value.groups.hours))
-                time.setMinutes(parseInt(value.groups.minutes))
-                time.setSeconds(0);
+                const startTime = new Date();
+                startTime.setHours(parseInt(value.groups.hours))
+                startTime.setMinutes(parseInt(value.groups.minutes))
+                startTime.setSeconds(0);
+
+                let endTimeRaw = ''
+                let endTime = new Date();
+                if (value.groups.endHours !== undefined && value.groups.endMinutes !== undefined) {
+                    endTime.setHours(parseInt(value.groups.endHours))
+                    endTime.setMinutes(parseInt(value.groups.endMinutes))
+                    endTime.setSeconds(0);
+
+                    endTimeRaw = `${value.groups.endHours.padStart(2, '0')}:${value.groups.endMinutes}`
+                } else {
+                    endTime = undefined;
+                }                
+                
                 return this.planItemFactory.getPlanItem(
                     match.index, 
                     value.index, 
                     isCompleted, 
                     isBreak,
                     isEnd,
-                    time, 
+                    startTime, 
+                    endTime,
                     `${value.groups.hours.padStart(2, '0')}:${value.groups.minutes}`,
+                    endTimeRaw,
                     value.groups.text?.trim(),
                     value[0]
                 );

--- a/src/plan-data.ts
+++ b/src/plan-data.ts
@@ -26,19 +26,22 @@ export class PlanSummaryData {
             }
             this.items.forEach((item, i) => {
                 const next = this.items[i+1];
-                if(item.time < now && (item.isEnd || (next && now < next.time))) {
+                if(item.startTime < now && (item.isEnd || (next && now < next.startTime))) {
                     this.current = item;
                     if (item.isEnd) {
                         item.isPast = true;
                         this.past.push(item);
                     }
                     this.next = item.isEnd ? null : next;
-                } else if(item.time < now) {
+                } else if(item.startTime < now) {
                     item.isPast = true;
                     this.past.push(item);
                 }
-                if(next){
-                    const untilNext = moment.duration(moment(next.time).diff(moment(item.time))).asMinutes();
+                
+                if (item.endTime !== undefined) {
+                    item.durationMins = moment.duration(moment(item.endTime).diff(moment(item.startTime))).asMinutes()
+                } else if(next){
+                    const untilNext = moment.duration(moment(next.startTime).diff(moment(item.startTime))).asMinutes();
                     item.durationMins = untilNext;
                 }
             });
@@ -57,21 +60,25 @@ export class PlanItem {
     isPast: boolean;
     isBreak: boolean;
     isEnd: boolean;
-    time: Date;
+    startTime: Date;
+    endTime: Date;
     durationMins: number;
-    rawTime: string;
+    rawStartTime: string;
+    rawEndTime: string;
     text: string;
     raw: string;
 
     constructor(matchIndex: number, charIndex: number, isCompleted: boolean, 
-        isBreak: boolean, isEnd: boolean, time: Date, rawTime:string, text: string, raw: string){
+        isBreak: boolean, isEnd: boolean, startTime: Date, endTime: Date, rawStartTime:string, rawEndTime:string, text: string, raw: string){
         this.matchIndex = matchIndex;
         this.charIndex = charIndex;
         this.isCompleted = isCompleted;
         this.isBreak = isBreak;
         this.isEnd = isEnd;
-        this.time = time;
-        this.rawTime = rawTime;
+        this.startTime = startTime;
+        this.endTime = endTime
+        this.rawStartTime = rawStartTime;
+        this.rawEndTime = rawEndTime;
         this.text = text;
         this.raw = raw;
     }
@@ -84,9 +91,9 @@ export class PlanItemFactory {
         this.settings = settings;
     }
 
-    getPlanItem(matchIndex: number, charIndex: number, isCompleted: boolean, isBreak: boolean, isEnd: boolean, time: Date, rawTime: string, text: string, raw: string) {
+    getPlanItem(matchIndex: number, charIndex: number, isCompleted: boolean, isBreak: boolean, isEnd: boolean, startTime: Date, endTime: Date, rawStartTime: string, rawEndTime: string, text: string, raw: string) {
         const displayText = this.getDisplayText(isBreak, isEnd, text);
-        return new PlanItem(matchIndex, charIndex, isCompleted, isBreak, isEnd, time, rawTime, displayText, raw);
+        return new PlanItem(matchIndex, charIndex, isCompleted, isBreak, isEnd, startTime, endTime, rawStartTime, rawEndTime, displayText, raw);
     }
 
     getDisplayText(isBreak: boolean, isEnd: boolean, text: string) {

--- a/src/planner-md.ts
+++ b/src/planner-md.ts
@@ -95,7 +95,13 @@ export default class PlannerMarkdown {
         if(!this.settings.completePastItems) {
             check = this.check(item.isCompleted);
         }
-        return `- [${check}] ${item.rawTime} ${item.text}`;
+
+        let outputTask = `- [${check}] ${item.rawStartTime} `
+        if (item.rawEndTime !== '') {
+            outputTask += `- ${item.rawEndTime} `
+        }
+
+        return  outputTask + `${item.text}`;
     }
 
     private check(check: boolean) {

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -6,8 +6,14 @@ export default class Progress {
         try {
             const now = new Date();
             const nowMoment = moment(now);
-            const currentMoment = moment(current.time);
-            const nextMoment = moment(next.time);
+            const currentMoment = moment(current.startTime);
+            let nextMoment: any;
+            if (current.endTime === undefined) {
+                nextMoment = moment(current.endTime)
+            } else {
+                nextMoment = moment(next.startTime)
+            }
+
             const diff = moment.duration(nextMoment.diff(currentMoment));
             const fromStart = moment.duration(nowMoment.diff(currentMoment));
             const untilNext = moment.duration(nextMoment.diff(nowMoment));

--- a/src/status-bar.ts
+++ b/src/status-bar.ts
@@ -136,9 +136,10 @@ export default class StatusBar {
     private statusText(minsUntilNext: string, current: PlanItem, next: PlanItem, percentageComplete: number) {
       minsUntilNext = minsUntilNext === '0' ? '1' : minsUntilNext;
       const minsText = `${minsUntilNext} min${minsUntilNext === '1' ? '' : 's'}`;
+      // TODO: do I need to add an end time here pjk
       if(this.settings.nowAndNextInStatusBar) {
-        this.statusBarText.innerHTML = `<strong>Now</strong> ${current.rawTime} ${this.ellipsis(current.text, 10)}`;
-        this.nextText.innerHTML = `<strong>Next</strong> ${next.rawTime} ${this.ellipsis(next.text, 10)}`;
+        this.statusBarText.innerHTML = `<strong>Now</strong> ${current.rawStartTime} ${this.ellipsis(current.text, 10)}`;
+        this.nextText.innerHTML = `<strong>Next</strong> ${next.rawStartTime} ${this.ellipsis(next.text, 10)}`;
         this.show(this.nextText);
       } else {
         this.hide(this.nextText);
@@ -146,19 +147,19 @@ export default class StatusBar {
         this.statusBarText.innerText = statusText;
       }
       const currentTaskStatus = `Current Task (${percentageComplete.toFixed(0)}% complete)`;
-      const currentTaskTimeAndText = `${current.rawTime} ${current.text}`;
+      const currentTaskTimeAndText = `${current.rawStartTime} ${current.text}`;
       const nextTask = `Next Task (in ${minsText})`;
-      const nextTaskTimeAndText = `${next.rawTime} ${next.text}`;
+      const nextTaskTimeAndText = `${next.rawStartTime} ${next.text}`;
       this.cardCurrent.innerHTML = `<strong>${currentTaskStatus}</strong><br> ${currentTaskTimeAndText}`;
       this.cardNext.innerHTML = `<strong>${nextTask}</strong><br> ${nextTaskTimeAndText}`;
       this.taskNotification(current, currentTaskTimeAndText, nextTask, nextTaskTimeAndText);
     }
 
     private taskNotification(current: PlanItem, currentTaskTimeAndText: string, nextTask: string, nextTaskText: string){
-      if(this.settings.showTaskNotification && this.currentTime !== undefined && this.currentTime !== current.time.toUTCString()){
+      if(this.settings.showTaskNotification && this.currentTime !== undefined && this.currentTime !== current.startTime.toUTCString()){
         new Notification(`Task started, ${currentTaskTimeAndText}`, {body: `${nextTask}: ${nextTaskText}`, requireInteraction: true});
       }
-      this.currentTime = current.time.toUTCString();
+      this.currentTime = current.startTime.toUTCString();
     }
 
     private ellipsis(input: string, limit: number){

--- a/src/timeline-view.ts
+++ b/src/timeline-view.ts
@@ -31,7 +31,7 @@ export default class TimelineView extends ItemView {
         planSummary.update(n => n = summaryData);
         const currentTime = new Date();
         now.update(n => n = currentTime);
-        const currentPosition = summaryData.empty ? 0 : this.positionFromTime(currentTime) - this.positionFromTime(summaryData.items.first().time);
+        const currentPosition = summaryData.empty ? 0 : this.positionFromTime(currentTime) - this.positionFromTime(summaryData.items.first().startTime);
         nowPosition.update(n => n = currentPosition);
         zoomLevel.update(n => n = this.settings.timelineZoomLevel);
     }

--- a/src/timeline.svelte
+++ b/src/timeline.svelte
@@ -65,7 +65,7 @@
     }
 
     function updateTimelineMeterPosition() {
-      timelineMeterPosition = summary.empty ? 0 : ((summary.items.first().time.getMinutes()*timelineZoomLevel)*-1) - 1;
+      timelineMeterPosition = summary.empty ? 0 : ((summary.items.first().startTime.getMinutes()*timelineZoomLevel)*-1) - 1;
     }
 
     function shortClass(item: PlanItem) {
@@ -74,6 +74,28 @@
 
     function pastClass(item: PlanItem) {
       return item.isPast ? 'past' : '';
+    }
+
+    function getClassesForEmptySlot(startDate: Date, endDate: Date) {
+      let classes: string;
+      let durationInMinutes = getTimeDifference(startDate, endDate)
+      const now = new Date();
+
+      if (durationInMinutes < (75/timelineZoomLevel)) {
+        classes += 'short'
+      }
+
+      if (now.getMilliseconds() >= endDate.getMilliseconds()) {
+        classes += ' past'
+      }
+
+      return classes
+    }
+
+    function getTimeDifference(startDate: Date, endDate: Date) {
+      let timeDiff = endDate.getMilliseconds() - startDate.getMilliseconds();
+      
+      return Math.round(((timeDiff % 86400000) % 3600000) / 60000);
     }
 
 </script>
@@ -154,7 +176,7 @@
   padding-bottom: 50px;
 }
 
-.event_item{
+.event_item, .empty_event{
     border-bottom: 2px solid var(--background-primary);
     margin: 0;
     cursor: pointer;
@@ -361,13 +383,19 @@ color:#fff;
         
       <div class="events">
         {#each summary.items as item, i}
-            <div class="event_item event_item_color{i%10+1} {shortClass(item)} {pastClass(item)}" style="height: {item.durationMins*timelineZoomLevel}px;" data-title="{item.rawTime}">
+            <div class="event_item event_item_color{i%10+1} {shortClass(item)} {pastClass(item)}" style="height: {item.durationMins*timelineZoomLevel}px;" data-title="{item.rawStartTime}">
               <div class="event_item_contents">
                 <div class="ei_Dot {item === summary.current ? 'dot_active' : ''}"></div>
-                <div class="ei_Title">{item.rawTime}</div>
+                <div class="ei_Title">{item.rawStartTime}</div>
                 <div class="ei_Copy">{item.text ?? ''}</div>
               </div>
             </div>
+
+            {#if item.rawEndTime !== '' && i+1 < summary.items.length}
+            <div class="empty_event {getClassesForEmptySlot(item.endTime, summary.items[i+1].startTime)}" style="height: {getTimeDifference(item.endTime, summary.items[i+1].startTime)*timelineZoomLevel}px;" data-title="empty">
+            </div>
+            {/if}
+            
         {/each}
       </div>
 

--- a/tests/fixtures/test.md
+++ b/tests/fixtures/test.md
@@ -5,6 +5,7 @@
 - [x] 10:00 meeting
 - [x] 11:00 ☕️ Coffee Break
 - [ ] 11:10 reading
+- [ ] 11:30 - 11:45 Short Jog
 - [ ] 12:00 writing
 - [ ] 13:00 ☕️ COFFEE BREAK
 - [ ] 13:10 meeting

--- a/tests/fixtures/test.md
+++ b/tests/fixtures/test.md
@@ -5,9 +5,10 @@
 - [x] 10:00 meeting
 - [x] 11:00 ☕️ Coffee Break
 - [ ] 11:10 reading
-- [ ] 11:30 - 11:45 Short Jog
+- [ ] 11:20 - 11:25 Short Jog
+- [ ] 11:30 -- 11:40 Shower
+- [ ] 11:45 – 11:50 Relax
 - [ ] 12:00 writing
 - [ ] 13:00 ☕️ COFFEE BREAK
 - [ ] 13:10 meeting
 - [ ] 14:00 🛑 Finish
-

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -20,41 +20,51 @@ describe('parser', () => {
 
     expect(results.empty).to.be.false;
     expect(results.invalid).to.be.false;
-    expect(results.items).to.have.lengthOf(9);
+    expect(results.items).to.have.lengthOf(10);
 
     const firstItem = results.items[0];
     expect(firstItem.isCompleted).to.be.true;
     expect(firstItem.isBreak).to.be.false;
     expect(firstItem.isEnd).to.be.false;
-    expect(firstItem.rawTime).to.eql('08:00');
+    expect(firstItem.rawStartTime).to.eql('08:00');
     expect(firstItem.text).to.eql('morning stuff');
 
     const fourthItem = results.items[3];
     expect(fourthItem.isCompleted).to.be.true;
     expect(fourthItem.isBreak).to.be.true;
     expect(fourthItem.isEnd).to.be.false;
-    expect(fourthItem.rawTime).to.eql('11:00');
+    expect(fourthItem.rawStartTime).to.eql('11:00');
     expect(fourthItem.text).to.eql('☕️ COFFEE BREAK');
 
     const fifthItem = results.items[4];
     expect(fifthItem.isCompleted).to.be.false;
     expect(fifthItem.isBreak).to.be.false;
     expect(fifthItem.isEnd).to.be.false;
-    expect(fifthItem.rawTime).to.eql('11:10');
+    expect(fifthItem.rawStartTime).to.eql('11:10');
+    expect(fifthItem.rawEndTime).to.eql('');
     expect(fifthItem.text).to.eql('reading');
 
-    const seventhItem = results.items[6];
-    expect(seventhItem.isCompleted).to.be.false;
-    expect(seventhItem.isBreak).to.be.true;
-    expect(seventhItem.isEnd).to.be.false;
-    expect(seventhItem.rawTime).to.eql('13:00');
-    expect(seventhItem.text).to.eql('☕️ COFFEE BREAK');
+    const ssixthItem = results.items[5];
+    expect(ssixthItem.isCompleted).to.be.false;
+    expect(ssixthItem.isBreak).to.be.false;
+    expect(ssixthItem.isEnd).to.be.false;
+    expect(ssixthItem.endTime).to.not.be.undefined;
+    expect(ssixthItem.rawStartTime).to.eql('11:30');
+    expect(ssixthItem.rawEndTime).to.eql('11:45');
+    expect(ssixthItem.text).to.eql('Short Jog');
 
-    const ninthItem = results.items[8];
-    expect(ninthItem.isCompleted).to.be.false;
-    expect(ninthItem.isBreak).to.be.false;
-    expect(ninthItem.isEnd).to.be.true;
-    expect(ninthItem.rawTime).to.eql('14:00');
-    expect(ninthItem.text).to.eql('🛑 FINISH');
+    const eigthItem = results.items[7];
+    expect(eigthItem.isCompleted).to.be.false;
+    expect(eigthItem.isBreak).to.be.true;
+    expect(eigthItem.isEnd).to.be.false;
+    expect(eigthItem.rawStartTime).to.eql('13:00');
+    expect(eigthItem.text).to.eql('☕️ COFFEE BREAK');
+
+    const tenthItem = results.items[9];
+    expect(tenthItem.isCompleted).to.be.false;
+    expect(tenthItem.isBreak).to.be.false;
+    expect(tenthItem.isEnd).to.be.true;
+    expect(tenthItem.rawStartTime).to.eql('14:00');
+    expect(tenthItem.text).to.eql('🛑 FINISH');
   });
 });

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -20,7 +20,7 @@ describe('parser', () => {
 
     expect(results.empty).to.be.false;
     expect(results.invalid).to.be.false;
-    expect(results.items).to.have.lengthOf(10);
+    expect(results.items).to.have.lengthOf(12);
 
     const firstItem = results.items[0];
     expect(firstItem.isCompleted).to.be.true;
@@ -44,27 +44,45 @@ describe('parser', () => {
     expect(fifthItem.rawEndTime).to.eql('');
     expect(fifthItem.text).to.eql('reading');
 
-    const ssixthItem = results.items[5];
-    expect(ssixthItem.isCompleted).to.be.false;
-    expect(ssixthItem.isBreak).to.be.false;
-    expect(ssixthItem.isEnd).to.be.false;
-    expect(ssixthItem.endTime).to.not.be.undefined;
-    expect(ssixthItem.rawStartTime).to.eql('11:30');
-    expect(ssixthItem.rawEndTime).to.eql('11:45');
-    expect(ssixthItem.text).to.eql('Short Jog');
+    const sixthItem = results.items[5];
+    expect(sixthItem.isCompleted).to.be.false;
+    expect(sixthItem.isBreak).to.be.false;
+    expect(sixthItem.isEnd).to.be.false;
+    expect(sixthItem.endTime).to.not.be.undefined;
+    expect(sixthItem.rawStartTime).to.eql('11:20');
+    expect(sixthItem.rawEndTime).to.eql('11:25');
+    expect(sixthItem.text).to.eql('Short Jog');
+  
+    const seventhItem = results.items[6];
+    expect(seventhItem.isCompleted).to.be.false;
+    expect(seventhItem.isBreak).to.be.false;
+    expect(seventhItem.isEnd).to.be.false;
+    expect(seventhItem.endTime).to.not.be.undefined;
+    expect(seventhItem.rawStartTime).to.eql('11:30');
+    expect(seventhItem.rawEndTime).to.eql('11:40');
+    expect(seventhItem.text).to.eql('Shower');
 
     const eigthItem = results.items[7];
     expect(eigthItem.isCompleted).to.be.false;
-    expect(eigthItem.isBreak).to.be.true;
+    expect(eigthItem.isBreak).to.be.false;
     expect(eigthItem.isEnd).to.be.false;
-    expect(eigthItem.rawStartTime).to.eql('13:00');
-    expect(eigthItem.text).to.eql('☕️ COFFEE BREAK');
+    expect(eigthItem.endTime).to.not.be.undefined;
+    expect(eigthItem.rawStartTime).to.eql('11:45');
+    expect(eigthItem.rawEndTime).to.eql('11:50');
+    expect(eigthItem.text).to.eql('Relax');
 
     const tenthItem = results.items[9];
     expect(tenthItem.isCompleted).to.be.false;
-    expect(tenthItem.isBreak).to.be.false;
-    expect(tenthItem.isEnd).to.be.true;
-    expect(tenthItem.rawStartTime).to.eql('14:00');
-    expect(tenthItem.text).to.eql('🛑 FINISH');
+    expect(tenthItem.isBreak).to.be.true;
+    expect(tenthItem.isEnd).to.be.false;
+    expect(tenthItem.rawStartTime).to.eql('13:00');
+    expect(tenthItem.text).to.eql('☕️ COFFEE BREAK');
+
+    const twelthItem = results.items[11];
+    expect(twelthItem.isCompleted).to.be.false;
+    expect(twelthItem.isBreak).to.be.false;
+    expect(twelthItem.isEnd).to.be.true;
+    expect(twelthItem.rawStartTime).to.eql('14:00');
+    expect(twelthItem.text).to.eql('🛑 FINISH');
   });
 });

--- a/tests/plan-data.test.ts
+++ b/tests/plan-data.test.ts
@@ -12,22 +12,23 @@ describe('plan-data', () => {
     const isBreak = false;
     const isEnd = false;
     const time = new Date('2021-04-11T11:10:00.507Z');
-    const rawTime = '11:10';
+    const rawStartTime = '11:10';
+    const rawEndTime = ''
     const text = 'meeting';
     const raw = '- [x] 11:10 meeting';
 
     it('should generate PlanItem with given text', () => {
       const factory = new PlanItemFactory(new DayPlannerSettings());
 
-      const item = factory.getPlanItem(matchIndex, charIndex, isCompleted, isBreak, isEnd, time, rawTime, text, raw);
+      const item = factory.getPlanItem(matchIndex, charIndex, isCompleted, isBreak, isEnd, time, undefined, rawStartTime, rawEndTime, text, raw);
 
       expect(item.matchIndex).to.eql(matchIndex);
       expect(item.charIndex).to.eql(charIndex);
       expect(item.isCompleted).to.eql(isCompleted);
       expect(item.isBreak).to.eql(isBreak);
       expect(item.isEnd).to.eql(isEnd);
-      expect(item.time).to.eql(time);
-      expect(item.rawTime).to.eql(rawTime);
+      expect(item.startTime).to.eql(time);
+      expect(item.rawStartTime).to.eql(rawStartTime);
       expect(item.text).to.eql(text);
       expect(item.raw).to.eql(raw);
     });
@@ -39,7 +40,7 @@ describe('plan-data', () => {
       const factory = new PlanItemFactory(settings);
 
       const isBreakOn = true;
-      const item = factory.getPlanItem(matchIndex, charIndex, isCompleted, isBreakOn, isEnd, time, rawTime, text, raw);
+      const item = factory.getPlanItem(matchIndex, charIndex, isCompleted, isBreakOn, isEnd, time, undefined, rawStartTime, rawEndTime, text, raw);
 
       expect(item.isBreak).to.eql(isBreakOn);
       expect(item.text).to.eql(settings.breakLabel);
@@ -52,7 +53,7 @@ describe('plan-data', () => {
       const factory = new PlanItemFactory(settings);
 
       const isEndOn = true;
-      const item = factory.getPlanItem(matchIndex, charIndex, isCompleted, isBreak, isEndOn, time, rawTime, text, raw);
+      const item = factory.getPlanItem(matchIndex, charIndex, isCompleted, isBreak, isEndOn, time, undefined, rawStartTime, rawEndTime, text, raw);
 
       expect(item.isEnd).to.eql(isEndOn);
       expect(item.text).to.eql(settings.endLabel);


### PR DESCRIPTION
This PR is meant to make sure that you can optionally specify the end time of a task (https://github.com/lynchjames/obsidian-day-planner/issues/129). This is meant to allow for predefined tasks to start and end without needing to specify a break or end task. Please make sure I did not break any standards or fail to update any area I needed to.

I did leave the mermaid js section alone as I was not sure what to do with it in particular.

Changes Made:
- updated regex to include end hours and end minutes as an optional group which is separated by -, -- or –
- change rawTime to rawStartTime and added rawEndTime
- added endTime to PlanItem in order to allow for end times to be present
- updated the constructor to take new params to initialize new PlanItem properties
- changed time to startTime
- updated the PlanItem duration calculation to use the endTime if it is present
- updated marking past tasks as complete to include the rawEndTime if present
- added a new css class and 2 functions to handle the class selection for an empty event and the size selection of the empty event
- updated test file to include a task that specifies an end time
- updated parser tests to check for the end time being present or missing
- fixed other tests broken by the addition of extra params

Note: the timeline does look off when dealing with times with an empty event. The ratio may need adjustment or more css rules may need to include the empty event class.